### PR TITLE
refactor: streamline hearing details workflows

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,0 +1,32 @@
+export const base64ToBlob = (
+  base64Data: string,
+  contentType = "application/octet-stream",
+): Blob => {
+  const byteCharacters = atob(base64Data);
+  const byteNumbers = new Array(byteCharacters.length)
+    .fill(0)
+    .map((_, index) => byteCharacters.charCodeAt(index));
+
+  const byteArray = new Uint8Array(byteNumbers);
+
+  return new Blob([byteArray], { type: contentType });
+};
+
+export const downloadBlobAsFile = (blob: Blob, fileName: string) => {
+  const blobUrl = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = blobUrl;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+};
+
+export const downloadBase64File = (
+  base64Data: string,
+  fileName: string,
+  contentType = "application/octet-stream",
+) => {
+  const blob = base64ToBlob(base64Data, contentType);
+  downloadBlobAsFile(blob, fileName);
+};


### PR DESCRIPTION
## Summary
- add reusable base64 download helpers for hearing document exports
- simplify hearing actions by sharing payload setup, unified success checks, and clearer comments

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d53b8b1d9083298c2248ac4798c5e4