### PR TITLE
Ensure My Cases refresh after status changes

### DIFF
--- a/src/features/hearings/manage/services/myCaseService.ts
+++ b/src/features/hearings/manage/services/myCaseService.ts
@@ -30,20 +30,27 @@ export const useMyCasesData = ({
   isLoading: boolean;
   totalPages: number;
 } => {
-  const { data, isLoading } = useGetMyCasesQuery({
-    UserType,
-    IDNumber,
-    PageNumber,
-    TableFor,
-    CaseStatus,
-    FileNumber,
-    MainGovernment,
-    SubGovernment,
-    SearchID,
-    Number700,
-    AcceptedLanguage,
-    SourceSystem,
-  });
+  const { data, isLoading } = useGetMyCasesQuery(
+    {
+      UserType,
+      IDNumber,
+      PageNumber,
+      TableFor,
+      CaseStatus,
+      FileNumber,
+      MainGovernment,
+      SubGovernment,
+      SearchID,
+      Number700,
+      AcceptedLanguage,
+      SourceSystem,
+    },
+    {
+      refetchOnMountOrArgChange: true,
+      refetchOnFocus: true,
+      refetchOnReconnect: true,
+    },
+  );
 
   let cases: CaseRecord[] = [];
   let totalPages = 1;


### PR DESCRIPTION
## Summary
- force the My Cases query to refetch when the list remounts or regains focus so status updates after actions are shown promptly

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e3a5325df883298f3ddaaddb6d1c67